### PR TITLE
Change Prettier config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,7 @@ class Es2015Writer extends BaseWriter {
             .then(template => {
                 return prettier.format(template, {
                     bracketSpacing: false,
+                    parser        : 'babel',
                     singleQuote   : true
                 });
             })


### PR DESCRIPTION
- Add missing parser option to the prettier format call, ([API](https://prettier.io/docs/en/api.html#prettierformatsource--options), [Option](https://prettier.io/docs/en/options.html#parser))

Screenshot, before and after (warning removed).
<img width="745" alt="Screen Shot 2020-02-06 at 7 34 53 PM" src="https://user-images.githubusercontent.com/139212/73990677-db448e00-4917-11ea-8165-e70a08db877e.png">
